### PR TITLE
Support older Pythons via tomli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ verify-consistent-pyproject-toml-python-requirements = "hooks.verify_consistent_
 
 [tool.poetry.dependencies]
 python = ">=3.8"
+tomli = { version = "*", python = "<3.11" }
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/hooks/verify_consistent_pyproject_toml_python_requirements.py
+++ b/src/hooks/verify_consistent_pyproject_toml_python_requirements.py
@@ -6,8 +6,13 @@ from __future__ import annotations
 
 import pathlib
 import sys
-import tomllib
 import typing as t
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
 
 RC_SUCCESS: t.Final[t.Literal[0]] = 0
 RC_FAILURE: t.Final[t.Literal[1]] = 1


### PR DESCRIPTION
Allow pre-commit to execute this hook on older Python versions by conditionally depending on tomli.