### PR TITLE
Support PEP 621 metadata

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,7 @@ trim_trailing_whitespace = true
 
 [{*.yaml,*.yml}]
 indent_size = 2
+
+[README.rst]
+# The README contains YAML examples that are 2-space indented.
+indent_size = 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_schedule: "quarterly"
 
 default_language_version:
-  python: "python3.12"
+  python: "python3.13"
 
 repos:
   - repo: "meta"
@@ -11,7 +11,7 @@ repos:
       - id: "check-useless-excludes"
 
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
-    rev: "v4.5.0"
+    rev: "v5.0.0"
     hooks:
       - id: "check-added-large-files"
       - id: "check-merge-conflict"
@@ -23,18 +23,17 @@ repos:
       - id: "trailing-whitespace"
 
   - repo: "https://github.com/asottile/pyupgrade"
-    rev: "v3.15.1"
+    rev: "v3.19.1"
     hooks:
       - id: "pyupgrade"
-        name: "Enforce Python 3.8+ idioms"
+        name: "Enforce Python 3.9+ idioms"
         args:
-          - "--py38-plus"
+          - "--py39-plus"
 
   - repo: "https://github.com/psf/black-pre-commit-mirror"
-    rev: "24.2.0"
+    rev: "24.10.0"
     hooks:
       - id: "black"
-        language_version: "python3.8"
 
   - repo: "https://github.com/pycqa/isort"
     rev: "5.13.2"
@@ -42,16 +41,13 @@ repos:
       - id: "isort"
 
   - repo: "https://github.com/pycqa/flake8"
-    rev: "7.0.0"
+    rev: "7.1.1"
     hooks:
       - id: "flake8"
         additional_dependencies:
-          - "flake8-bugbear==24.2.6"
+          - "flake8-bugbear==24.12.12"
 
   - repo: "https://github.com/editorconfig-checker/editorconfig-checker.python"
-    rev: "2.7.3"
+    rev: "3.0.3"
     hooks:
       - id: "editorconfig-checker"
-        # The README contains YAML examples that are 2-space indented,
-        # so it is ignored here.
-        exclude: "README.rst"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,7 +6,10 @@
     The root ``/pyproject.toml`` file is considered authoritative;
     all other ``pyproject.toml`` files must match it exactly.
 
-    The Python requirement location is ``tool.poetry.dependencies.python``.
+    In order, the Python requirement locations checked are:
+
+    * ``project.requires-python``
+    * ``tool.poetry.dependencies.python``
 
     For example, if the root ``pyproject.toml`` file specifies ``">=3.8"``,
     all other ``pyproject.toml`` files must also specify ``">=3.8"``.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2024 Kurt McKee <contactme@kurtmckee.org>
+Copyright 2024-2025 Kurt McKee <contactme@kurtmckee.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,8 @@
+..
+    This file is part of a pre-commit hook repository.
+    Copyright 2024-2025 Kurt McKee <contactme@kurtmckee.org>
+    SPDX-License-Identifier: MIT
+
 Pre-commit hooks
 ################
 
@@ -8,8 +13,8 @@ The `pre-commit`_ hooks in this repository help me maintain my own projects.
 ``verify-consistent-pyproject-toml-python-requirements``
 ========================================================
 
-Enforces that the ``tool.poetry.dependencies.python`` value matches
-across ``pyproject.toml`` files in a given repository.
+Enforces that ``project.requires-python`` and ``tool.poetry.dependencies.python`` values
+match across ``pyproject.toml`` files in a given repository.
 
 By default, only ``pyproject.toml`` files in a ``requirements/`` subdirectory are checked.
 This can be customized by setting ``args`` in the ``.pre-commit.hooks.yaml`` configuration:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,27 @@
-[tool.poetry]
+[project]
 name = "pre-commit-hooks"
 version = "0.1.1"
 description = "Pre-commit hooks that help me"
-authors = ["Kurt McKee <contactme@kurtmckee.org>"]
+authors = [
+    { name = "Kurt McKee", email = "contactme@kurtmckee.org" },
+]
 license = "MIT"
 readme = "README.rst"
-packages = [{include = "hooks", from = "src"}]
+requires-python = ">=3.9"
+dependencies = [
+    "tomli ; python_version < '3.11'",
+]
 
-[tool.poetry.scripts]
+[project.scripts]
 verify-consistent-pyproject-toml-python-requirements = "hooks.verify_consistent_pyproject_toml_python_requirements:main"
-
-[tool.poetry.dependencies]
-python = ">=3.8"
-tomli = { version = "*", python = "<3.11" }
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+
+# poetry
+# ------
+
+[tool.poetry]
+packages = [{include = "hooks", from = "src"}]

--- a/src/hooks/verify_consistent_pyproject_toml_python_requirements.py
+++ b/src/hooks/verify_consistent_pyproject_toml_python_requirements.py
@@ -1,5 +1,5 @@
 # This file is part of a pre-commit hook repository.
-# Copyright 2024 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2024-2025 Kurt McKee <contactme@kurtmckee.org>
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -59,16 +59,22 @@ def _get_toml_python_requirement(path: pathlib.Path) -> str:
         raise AssertionError(f"'{path}' does not exist")
     try:
         standard_config = tomllib.loads(path.read_text(encoding="utf-8"))
-        python_requirement = standard_config["tool"]["poetry"]["dependencies"]["python"]
+        try:
+            # PEP 621 is favored, followed by Poetry.
+            python_requirement = standard_config["project"]["requires-python"]
+        except KeyError:
+            python_requirement = standard_config["tool"]["poetry"]["dependencies"][
+                "python"
+            ]
     except UnicodeDecodeError:
         raise AssertionError(f"'{path}' could not be decoded as UTF-8")
     except tomllib.TOMLDecodeError:
         raise AssertionError(f"'{path}' could not be parsed as TOML")
     except KeyError:
-        message = f"'{path}' does not contain a 'tool.poetry.dependencies.python' key"
+        message = f"'{path}' does not contain a 'project.requires-python' key"
         raise AssertionError(message)
     if not isinstance(python_requirement, str):
-        message = f"'{path}' has a non-string 'tool.poetry.dependencies.python' value"
+        message = f"'{path}' has a non-string 'project.requires-python' value"
         raise AssertionError(message)
 
     return python_requirement


### PR DESCRIPTION
Also:

* Update the copyright years.
* Configure the README's indentation in the EditorConfig, rather than excluding it from a pre-commit hooks.
* Update the pre-commit hooks.